### PR TITLE
Destroy lunch/menu item association when MenuItem is destroyed

### DIFF
--- a/models.rb
+++ b/models.rb
@@ -36,7 +36,7 @@ class MenuItem
 	property :description,			Text, required: true
 	
 	has n, :reviews
-	has n, :lunch_menu_items
+	has n, :lunch_menu_items, constraint: :destroy
 	has n, :lunches, through: :lunch_menu_items
 	
 	def avg_rating


### PR DESCRIPTION
`MenuItem` objects that were associated with an existing `Lunch` couldn't be deleted because it would create `LunchMenuItem` objects with invalid references to `MenuItem` objects.  Add `constraint: :destroy` so that when we delete a `MenuItem` object all associated `LunchMenuItem` objects are also destroyed.
